### PR TITLE
Add `py.typed` to support type checkers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,4 +27,7 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
+    package_data={
+        "": ["*py.typed"],
+    },
 )


### PR DESCRIPTION
This library is very well typed and annotated, but type checkers, e.g. `mypy`, can't use it because the library does not conform to PEP-561.

https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages

Add `py.typed` file to the package installation so that type checkers know that the module is typed.