### PR TITLE
Skip before_lt only when it's None

### DIFF
--- a/pytonapi/async_tonapi/methods/accounts.py
+++ b/pytonapi/async_tonapi/methods/accounts.py
@@ -105,7 +105,7 @@ class AccountsMethod(AsyncTonapiClient):
         """
         method = f"v2/accounts/{account_id}/jettons/history"
         params = {"limit": limit}
-        if before_lt:
+        if before_lt is not None:
             params["before_lt"] = before_lt
         if subject_only:
             params["subject_only"] = "true"
@@ -145,7 +145,7 @@ class AccountsMethod(AsyncTonapiClient):
         """
         method = f"v2/accounts/{account_id}/jettons/{jetton_id}/history"
         params = {"limit": limit}
-        if before_lt:
+        if before_lt is not None:
             params["before_lt"] = before_lt
         if subject_only:
             params["subject_only"] = "true"
@@ -251,7 +251,7 @@ class AccountsMethod(AsyncTonapiClient):
         """
         method = f"v2/accounts/{account_id}/events"
         params = {"limit": limit}
-        if before_lt:
+        if before_lt is not None:
             params["before_lt"] = before_lt
         if subject_only:
             params["subject_only"] = "true"
@@ -325,7 +325,7 @@ class AccountsMethod(AsyncTonapiClient):
         """
         method = f"v2/accounts/{account_id}/nfts/history"
         params = {"limit": limit}
-        if before_lt:
+        if before_lt is not None:
             params["before_lt"] = before_lt
         if subject_only:
             params["subject_only"] = "true"

--- a/pytonapi/async_tonapi/methods/inscriptions.py
+++ b/pytonapi/async_tonapi/methods/inscriptions.py
@@ -44,7 +44,7 @@ class InscriptionsMethod(AsyncTonapiClient):
         """
         method = f"v2/experimental/accounts/{account_id}/inscriptions/history"
         params = {"limit": limit}
-        if before_lt:
+        if before_lt is not None:
             params["before_lt"] = before_lt
         headers = {"Accept-Language": accept_language}
         response = await self._get(method=method, params=params, headers=headers)
@@ -70,7 +70,7 @@ class InscriptionsMethod(AsyncTonapiClient):
         """
         method = f"v2/experimental/accounts/{account_id}/inscriptions/{ticker}/history"
         params = {"limit": limit}
-        if before_lt:
+        if before_lt is not None:
             params["before_lt"] = before_lt
         headers = {"Accept-Language": accept_language}
         response = await self._get(method=method, params=params, headers=headers)

--- a/pytonapi/async_tonapi/methods/nft.py
+++ b/pytonapi/async_tonapi/methods/nft.py
@@ -124,7 +124,7 @@ class NftMethod(AsyncTonapiClient):
         """
         method = f"v2/nfts/{account_id}/history"
         params = {"limit": limit}
-        if before_lt:
+        if before_lt is not None:
             params["before_lt"] = before_lt
         if subject_only:
             params["subject_only"] = "true"

--- a/pytonapi/tonapi/methods/accounts.py
+++ b/pytonapi/tonapi/methods/accounts.py
@@ -105,7 +105,7 @@ class AccountsMethod(TonapiClient):
         """
         method = f"v2/accounts/{account_id}/jettons/history"
         params = {"limit": limit}
-        if before_lt:
+        if before_lt is not None:
             params["before_lt"] = before_lt
         if subject_only:
             params["subject_only"] = "true"
@@ -145,7 +145,7 @@ class AccountsMethod(TonapiClient):
         """
         method = f"v2/accounts/{account_id}/jettons/{jetton_id}/history"
         params = {"limit": limit}
-        if before_lt:
+        if before_lt is not None:
             params["before_lt"] = before_lt
         if subject_only:
             params["subject_only"] = "true"
@@ -251,7 +251,7 @@ class AccountsMethod(TonapiClient):
         """
         method = f"v2/accounts/{account_id}/events"
         params = {"limit": limit}
-        if before_lt:
+        if before_lt is not None:
             params["before_lt"] = before_lt
         if subject_only:
             params["subject_only"] = "true"
@@ -325,7 +325,7 @@ class AccountsMethod(TonapiClient):
         """
         method = f"v2/accounts/{account_id}/nfts/history"
         params = {"limit": limit}
-        if before_lt:
+        if before_lt is not None:
             params["before_lt"] = before_lt
         if subject_only:
             params["subject_only"] = "true"

--- a/pytonapi/tonapi/methods/blockchain.py
+++ b/pytonapi/tonapi/methods/blockchain.py
@@ -197,8 +197,8 @@ class BlockchainMethod(TonapiClient):
         """
         method = f"v2/blockchain/accounts/{account_id}/transactions"
         params = {"limit": limit}
-        if before_lt: params["before_lt"] = before_lt  # noqa E701
-        if after_lt: params["after_lt"] = after_lt  # noqa E701
+        if before_lt is not None: params["before_lt"] = before_lt  # noqa E701
+        if after_lt is not None: params["after_lt"] = after_lt  # noqa E701
         response = self._get(method=method, params=params)
 
         return Transactions(**response)

--- a/pytonapi/tonapi/methods/inscriptions.py
+++ b/pytonapi/tonapi/methods/inscriptions.py
@@ -44,7 +44,7 @@ class InscriptionsMethod(TonapiClient):
         """
         method = f"v2/experimental/accounts/{account_id}/inscriptions/history"
         params = {"limit": limit}
-        if before_lt:
+        if before_lt is not None:
             params["before_lt"] = before_lt
         headers = {"Accept-Language": accept_language}
         response = self._get(method=method, params=params, headers=headers)
@@ -70,7 +70,7 @@ class InscriptionsMethod(TonapiClient):
         """
         method = f"v2/experimental/accounts/{account_id}/inscriptions/{ticker}/history"
         params = {"limit": limit}
-        if before_lt:
+        if before_lt is not None:
             params["before_lt"] = before_lt
         headers = {"Accept-Language": accept_language}
         response = self._get(method=method, params=params, headers=headers)

--- a/pytonapi/tonapi/methods/nft.py
+++ b/pytonapi/tonapi/methods/nft.py
@@ -120,7 +120,7 @@ class NftMethod(TonapiClient):
         """
         method = f"v2/nfts/{account_id}/history"
         params = {"limit": limit}
-        if before_lt: params["before_lt"] = before_lt  # noqa:E701
+        if before_lt is not None: params["before_lt"] = before_lt  # noqa:E701
         if subject_only: params["subject_only"] = "true"  # noqa:E701
         if start_date: params["start_date"] = start_date  # noqa:E701
         if end_date: params["end_date"] = end_date  # noqa:E701


### PR DESCRIPTION
Cursor based pagination relies on `before_lt` and at the last page the value of the cursor `next_from`(eg. `accounts.get_events()`) is `0` which was getting skipped because `if 0:` is falsy.
Added `is not None` check to all `before_lt` and `after_lt` conditional checks, similar to 2e448761f5af0090de4975653c6e132a4118ead6