### PR TITLE
Fix `currencies` in `v2/accounts/{account_id}/jettons`

### DIFF
--- a/pytonapi/schema/rates.py
+++ b/pytonapi/schema/rates.py
@@ -12,7 +12,7 @@ class ChartRates(BaseModel):
 
 
 class TokenRates(BaseModel):
-    prices: Optional[Dict[str, str]] = None
+    prices: Optional[Dict[str, Union[float, int]]] = None
     diff_24h: Optional[Dict[str, str]] = None
     diff_7d: Optional[Dict[str, str]] = None
     diff_30d: Optional[Dict[str, str]] = None

--- a/tests/tonapi/test_accounts_methods.py
+++ b/tests/tonapi/test_accounts_methods.py
@@ -25,6 +25,10 @@ class TestAccountMethod(TestTonapi):
         response = self.tonapi.accounts.get_jettons_balances(ACCOUNT_ID)
         self.assertIsInstance(response, schema.jettons.JettonsBalances)
 
+    def test_get_jettons_with_currencies(self):
+        response = self.tonapi.accounts.get_jettons_balances(ACCOUNT_ID, currencies=["ton"])
+        self.assertIsInstance(response, schema.jettons.JettonsBalances)
+
     def test_get_jetton(self):
         response = self.tonapi.accounts.get_jetton_balance(ACCOUNT_ID, JETTON_ID)
         self.assertIsInstance(response, schema.jettons.JettonBalance)


### PR DESCRIPTION
Fix pydantic schema to support currencies. 

OpenApi scheme states that it needs to be number, but in the library `str` is used, raising pydantic exception
https://github.com/tonkeeper/opentonapi/blob/1115a8afe8d53995ffe6a9c7b2d6982a39866bda/api/openapi.yml#L7351-L7360