### PR TITLE
Add hash field to Message Model

### DIFF
--- a/pytonapi/schema/traces.py
+++ b/pytonapi/schema/traces.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Optional, List, Union
+from typing import List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -92,6 +92,7 @@ class Message(BaseModel):
     init: Optional[StateInit] = None
     decoded_op_name: Optional[str] = None
     decoded_body: Optional[Union[dict, str]] = None
+    hash: Optional[str] = None
     raw_body: Optional[str] = None
 
 


### PR DESCRIPTION
Fix pydantic schema to support hash in message model
The OpenApi schema specifies that the message has a "_hash_" field, but it is not present in the library

https://github.com/tonkeeper/opentonapi/blob/master/api/openapi.json#L4129-L4132